### PR TITLE
Rename pipe/pool

### DIFF
--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -6,14 +6,14 @@ import (
 	"reflect"
 	"testing"
 
-	"pipelined.dev/signal"
-
 	"pipelined.dev/pipe"
 	"pipelined.dev/pipe/internal/runner"
 	"pipelined.dev/pipe/metric"
 	"pipelined.dev/pipe/mock"
 	"pipelined.dev/pipe/mutability"
-	"pipelined.dev/pipe/pool"
+	"pipelined.dev/pipe/pooling"
+
+	"pipelined.dev/signal"
 )
 
 var testError = errors.New("test runner error")
@@ -28,7 +28,7 @@ func TestSource(t *testing.T) {
 		source, props, _ := sourceAllocator(bufferSize)
 		return runner.Source{
 			Mutability: source.Mutability,
-			Output: pool.Get(signal.Allocator{
+			Output: pooling.Get(signal.Allocator{
 				Channels: props.Channels,
 				Length:   bufferSize,
 				Capacity: bufferSize,
@@ -128,12 +128,12 @@ func TestProcessor(t *testing.T) {
 		processor, props, _ := processorAllocator(bufferSize, pipe.SignalProperties{Channels: channels})
 		return runner.Processor{
 			Mutability: processor.Mutability,
-			Input: pool.Get(signal.Allocator{
+			Input: pooling.Get(signal.Allocator{
 				Channels: props.Channels,
 				Length:   bufferSize,
 				Capacity: bufferSize,
 			}),
-			Output: pool.Get(signal.Allocator{
+			Output: pooling.Get(signal.Allocator{
 				Channels: props.Channels,
 				Length:   bufferSize,
 				Capacity: bufferSize,
@@ -239,7 +239,7 @@ func TestSink(t *testing.T) {
 		sink, _ := sinkAllocator(bufferSize, pipe.SignalProperties{Channels: channels})
 		return runner.Sink{
 			Mutability: sink.Mutability,
-			Input: pool.Get(signal.Allocator{
+			Input: pooling.Get(signal.Allocator{
 				Channels: channels,
 				Length:   bufferSize,
 				Capacity: bufferSize,

--- a/pipe.go
+++ b/pipe.go
@@ -9,7 +9,7 @@ import (
 	"pipelined.dev/pipe/internal/runner"
 	"pipelined.dev/pipe/metric"
 	"pipelined.dev/pipe/mutability"
-	"pipelined.dev/pipe/pool"
+	"pipelined.dev/pipe/pooling"
 )
 
 type (
@@ -159,7 +159,7 @@ func (fn SourceAllocatorFunc) runner(bufferSize int) (runner.Source, SignalPrope
 	}
 	return runner.Source{
 		Mutability: source.Mutability,
-		Output: pool.Get(signal.Allocator{
+		Output: pooling.Get(signal.Allocator{
 			Channels: props.Channels,
 			Length:   bufferSize,
 			Capacity: bufferSize,
@@ -177,12 +177,12 @@ func (fn ProcessorAllocatorFunc) runner(bufferSize int, input SignalProperties) 
 	}
 	return runner.Processor{
 		Mutability: processor.Mutability,
-		Input: pool.Get(signal.Allocator{
+		Input: pooling.Get(signal.Allocator{
 			Channels: input.Channels,
 			Length:   bufferSize,
 			Capacity: bufferSize,
 		}),
-		Output: pool.Get(signal.Allocator{
+		Output: pooling.Get(signal.Allocator{
 			Channels: output.Channels,
 			Length:   bufferSize,
 			Capacity: bufferSize,
@@ -200,7 +200,7 @@ func (fn SinkAllocatorFunc) runner(bufferSize int, input SignalProperties) (runn
 	}
 	return runner.Sink{
 		Mutability: sink.Mutability,
-		Input: pool.Get(signal.Allocator{
+		Input: pooling.Get(signal.Allocator{
 			Channels: input.Channels,
 			Length:   bufferSize,
 			Capacity: bufferSize,

--- a/pooling/pooling.go
+++ b/pooling/pooling.go
@@ -1,10 +1,10 @@
 /*
-Package pool provides cache for signal pools.
+Package pooling provides cache for signal pools.
 
 The main use case for this package is to utilise pools with the same
 allocators across multiple DSP components.
 */
-package pool
+package pooling
 
 import (
 	"sync"

--- a/pooling/pooling_test.go
+++ b/pooling/pooling_test.go
@@ -1,9 +1,10 @@
-package pool_test
+package pooling_test
 
 import (
 	"testing"
 
-	"pipelined.dev/pipe/pool"
+	"pipelined.dev/pipe/pooling"
+
 	"pipelined.dev/signal"
 )
 
@@ -13,14 +14,14 @@ func TestPool(t *testing.T) {
 		Length:   512,
 	}
 
-	p1 := pool.Get(alloc)
-	p2 := pool.Get(alloc)
+	p1 := pooling.Get(alloc)
+	p2 := pooling.Get(alloc)
 	if p1 != p2 {
 		t.Fatal("p1 must be equal to p2")
 	}
 
-	pool.Wipe()
-	p3 := pool.Get(alloc)
+	pooling.Wipe()
+	p3 := pooling.Get(alloc)
 	if p1 == p3 {
 		t.Fatal("p1 must not be equal to p3")
 	}


### PR DESCRIPTION
Because the name seems to be confusing with local variables, renamed to `pipe/pooling`