### PR TITLE
New Lines helper

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -110,6 +110,20 @@ type (
 	}
 )
 
+// Lines is a helper function that allows to bind multiple routes with
+// using same buffer size.
+func Lines(bufferSize int, routes ...Routing) ([]Line, error) {
+	var lines []Line
+	for i := range routes {
+		l, err := routes[i].Line(bufferSize)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, l)
+	}
+	return lines, nil
+}
+
 // Line binds components. All allocators are executed and wrapped into
 // runners. If any of allocators failed, the error will be returned and
 // flush hooks won't be triggered.

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -76,30 +76,30 @@ func TestReset(t *testing.T) {
 
 func TestAddLine(t *testing.T) {
 	sink1 := &mock.Sink{Discard: true}
-	line1, err := pipe.Routing{
-		Source: (&mock.Source{
-			Limit:    862 * bufferSize,
-			Channels: 2,
-		}).Source(),
-		Sink: sink1.Sink(),
-	}.Line(bufferSize)
-	assertNil(t, "error", err)
-
 	sink2 := &mock.Sink{Discard: true}
-	line2, err := pipe.Routing{
-		Source: (&mock.Source{
-			Limit:    862 * bufferSize,
-			Channels: 2,
-		}).Source(),
-		Sink: sink2.Sink(),
-	}.Line(bufferSize)
+	lines, err := pipe.Lines(bufferSize,
+		pipe.Routing{
+			Source: (&mock.Source{
+				Limit:    862 * bufferSize,
+				Channels: 2,
+			}).Source(),
+			Sink: sink1.Sink(),
+		},
+		pipe.Routing{
+			Source: (&mock.Source{
+				Limit:    862 * bufferSize,
+				Channels: 2,
+			}).Source(),
+			Sink: sink2.Sink(),
+		},
+	)
 	assertNil(t, "error", err)
 
 	p := pipe.New(
 		context.Background(),
-		pipe.WithLines(line1),
+		pipe.WithLines(lines[0]),
 	)
-	p.Push(p.AddLine(line2))
+	p.Push(p.AddLine(lines[1]))
 
 	// start
 	err = p.Wait()


### PR DESCRIPTION
`pipe.Lines` allows to bind multiple routes with the same buffer size