### PR TITLE
Refactoring lines API

### DIFF
--- a/internal/fitting/fitting.go
+++ b/internal/fitting/fitting.go
@@ -16,7 +16,6 @@ type (
 
 	// Sender sends the message.
 	Sender interface {
-		Bind()
 		Send(context.Context, Message) bool
 		Close()
 	}
@@ -55,7 +54,9 @@ func Sync() Fitting {
 // Async is a fitting that connects two components executed in different
 // goroutines.
 func Async() Fitting {
-	return &asyncFitting{}
+	return &asyncFitting{
+		messageChan: make(chan Message, 1),
+	}
 }
 
 func (l *syncFitting) Send(_ context.Context, m Message) bool {
@@ -77,8 +78,6 @@ func (l *syncFitting) Close() {
 	l.closed = true
 	return
 }
-
-func (l *syncFitting) Bind() {}
 
 func (l *asyncFitting) Send(ctx context.Context, m Message) bool {
 	select {
@@ -104,8 +103,4 @@ func (l *asyncFitting) Receive(ctx context.Context) (Message, bool) {
 func (l *asyncFitting) Close() {
 	close(l.messageChan)
 	return
-}
-
-func (l *asyncFitting) Bind() {
-	l.messageChan = make(chan Message, 1)
 }

--- a/internal/fitting/fitting.go
+++ b/internal/fitting/fitting.go
@@ -76,7 +76,6 @@ func (l *syncFitting) Receive(context.Context) (Message, bool) {
 
 func (l *syncFitting) Close() {
 	l.closed = true
-	return
 }
 
 func (l *asyncFitting) Send(ctx context.Context, m Message) bool {
@@ -102,5 +101,4 @@ func (l *asyncFitting) Receive(ctx context.Context) (Message, bool) {
 
 func (l *asyncFitting) Close() {
 	close(l.messageChan)
-	return
 }

--- a/line.go
+++ b/line.go
@@ -93,7 +93,7 @@ func (p *Pipe) addExecutors(r *route, routeIdx int) {
 	if r.context.IsMutable() {
 		if e, ok := p.executors[r.context]; ok {
 			mle := e.(*multiLineExecutor)
-			mle.Lines = append(mle.Lines, r.executor(mle.Destination, routeIdx))
+			mle.executors = append(mle.executors, r.executor(mle.Destination, routeIdx))
 			return
 		}
 		d := mutable.NewDestination()
@@ -101,7 +101,7 @@ func (p *Pipe) addExecutors(r *route, routeIdx int) {
 		p.executors[r.context] = &multiLineExecutor{
 			Context:     r.context,
 			Destination: d,
-			Lines:       []*lineExecutor{r.executor(d, routeIdx)},
+			executors:   []*lineExecutor{r.executor(d, routeIdx)},
 		}
 		return
 	}

--- a/line.go
+++ b/line.go
@@ -40,15 +40,6 @@ type (
 		Channels   int
 	}
 
-	AsyncLine Line
-	// SyncLine  Line
-	SyncLines []Line
-
-	// Starter interface {
-	// 	Starter(bufferSize int, p mutable.Pusher) (starter, mutable.Destination, error)
-	// 	// bindContexts(p mutable.Pusher, d mutable.Destination)
-	// }
-
 	// line represents a bound components
 	line struct {
 		context    mutable.Context

--- a/line.go
+++ b/line.go
@@ -101,43 +101,43 @@ func (l Line) route(bufferSize int) (*route, error) {
 	}, nil
 }
 
-func (l *route) bindExecutors(executors map[mutable.Context]executor, p mutable.Pusher) {
-	if l.context.IsMutable() {
-		if e, ok := executors[l.context]; ok {
+func (r *route) bindExecutors(executors map[mutable.Context]executor, p mutable.Pusher) {
+	if r.context.IsMutable() {
+		if e, ok := executors[r.context]; ok {
 			mle := e.(*multiLineExecutor)
-			mle.Lines = append(mle.Lines, l.executor(mle.Destination))
+			mle.Lines = append(mle.Lines, r.executor(mle.Destination))
 		} else {
 			d := mutable.NewDestination()
-			p.AddDestination(l.context, d)
-			executors[l.context] = &multiLineExecutor{
-				Context:     l.context,
+			p.AddDestination(r.context, d)
+			executors[r.context] = &multiLineExecutor{
+				Context:     r.context,
 				Destination: d,
-				Lines:       []*lineExecutor{l.executor(d)},
+				Lines:       []*lineExecutor{r.executor(d)},
 			}
 		}
 		return
 	}
 
 	d := mutable.NewDestination()
-	l.source.dest = d
-	p.AddDestination(l.source.Context, d)
-	executors[l.source.Context] = &l.source
-	for i := range l.processors {
-		p.AddDestination(l.processors[i].Context, d)
-		executors[l.processors[i].Context] = &l.processors[i]
+	r.source.dest = d
+	p.AddDestination(r.source.Context, d)
+	executors[r.source.Context] = &r.source
+	for i := range r.processors {
+		p.AddDestination(r.processors[i].Context, d)
+		executors[r.processors[i].Context] = &r.processors[i]
 	}
-	p.AddDestination(l.sink.Context, d)
-	executors[l.sink.Context] = &l.sink
+	p.AddDestination(r.sink.Context, d)
+	executors[r.sink.Context] = &r.sink
 }
 
-func (l *route) executor(d mutable.Destination) *lineExecutor {
-	executors := make([]executor, 0, 2+len(l.processors))
-	l.source.dest = d
-	executors = append(executors, &l.source)
-	for i := range l.processors {
-		executors = append(executors, &l.processors[i])
+func (r *route) executor(d mutable.Destination) *lineExecutor {
+	executors := make([]executor, 0, 2+len(r.processors))
+	r.source.dest = d
+	executors = append(executors, &r.source)
+	for i := range r.processors {
+		executors = append(executors, &r.processors[i])
 	}
-	executors = append(executors, &l.sink)
+	executors = append(executors, &r.sink)
 	return &lineExecutor{
 		executors: executors,
 	}

--- a/line.go
+++ b/line.go
@@ -89,35 +89,6 @@ func (l Line) route(bufferSize int) (*route, error) {
 	}, nil
 }
 
-func (p *Pipe) addExecutors(r *route, routeIdx int) {
-	if r.context.IsMutable() {
-		if e, ok := p.executors[r.context]; ok {
-			mle := e.(*multiLineExecutor)
-			mle.executors = append(mle.executors, r.executor(mle.Destination, routeIdx))
-			return
-		}
-		d := mutable.NewDestination()
-		p.pusher.AddDestination(r.context, d)
-		p.executors[r.context] = &multiLineExecutor{
-			Context:     r.context,
-			Destination: d,
-			executors:   []*lineExecutor{r.executor(d, routeIdx)},
-		}
-		return
-	}
-
-	d := mutable.NewDestination()
-	r.source.dest = d
-	p.pusher.AddDestination(r.source.Context, d)
-	p.executors[r.source.Context] = r.source
-	for i := range r.processors {
-		p.pusher.AddDestination(r.processors[i].Context, d)
-		p.executors[r.processors[i].Context] = r.processors[i]
-	}
-	p.pusher.AddDestination(r.sink.Context, d)
-	p.executors[r.sink.Context] = r.sink
-}
-
 func (r *route) connect(bufferSize int) {
 	fn := fitting.Async
 	if r.context.IsMutable() {

--- a/line.go
+++ b/line.go
@@ -145,6 +145,14 @@ func (r *route) executor(d mutable.Destination) *lineExecutor {
 	}
 }
 
+func (r *route) prev(pos int) (SignalProperties, out) {
+	if pos == 0 {
+		return r.source.SignalProperties, r.source.out
+	}
+	p := r.processors[pos-1]
+	return p.SignalProperties, p.out
+}
+
 func (fn SourceAllocatorFunc) allocate(ctx mutable.Context, bufferSize int) (Source, error) {
 	c, err := fn(ctx, bufferSize)
 	if err != nil {

--- a/line_test.go
+++ b/line_test.go
@@ -1,7 +1,6 @@
 package pipe_test
 
 import (
-	"context"
 	"testing"
 
 	"pipelined.dev/pipe"
@@ -14,9 +13,9 @@ func TestLine(t *testing.T) {
 		Sink:   (&mock.Sink{}).Sink(),
 	}
 
-	r, err := l.Runner(bufferSize, nil)
+	_, err := l.Runner(bufferSize, nil)
 	assertNil(t, "runner error", err)
 
-	err = r.Run(context.Background())
+	// err = r.Run(context.Background())
 	assertNil(t, "run error", err)
 }

--- a/line_test.go
+++ b/line_test.go
@@ -1,6 +1,7 @@
 package pipe_test
 
 import (
+	"context"
 	"testing"
 
 	"pipelined.dev/pipe"
@@ -13,9 +14,6 @@ func TestLine(t *testing.T) {
 		Sink:   (&mock.Sink{}).Sink(),
 	}
 
-	_, err := l.Runner(bufferSize, nil)
-	assertNil(t, "runner error", err)
-
-	// err = r.Run(context.Background())
+	err := pipe.Run(context.Background(), bufferSize, l)
 	assertNil(t, "run error", err)
 }

--- a/merger.go
+++ b/merger.go
@@ -1,19 +1,29 @@
 package pipe
 
 import (
+	"context"
 	"sync"
 )
 
 type (
 	// errorMerger allows to listen to multiple error channels.
 	errorMerger struct {
+		ctx       context.Context
 		wg        sync.WaitGroup
 		errorChan chan error
 	}
 )
 
+func newErrorMerger(ctx context.Context) *errorMerger {
+	return &errorMerger{
+		ctx:       ctx,
+		errorChan: make(chan error, 1),
+	}
+}
+
 // add error channels from all components into one.
-func (m *errorMerger) add(errc <-chan error) {
+func (m *errorMerger) add(e executor) {
+	errc := start(m.ctx, e)
 	// function to wait for error channel
 	m.wg.Add(1)
 	go m.listen(errc)

--- a/mutable/pusher.go
+++ b/mutable/pusher.go
@@ -30,15 +30,6 @@ func NewDestination() Destination {
 	return make(chan Mutations, 1)
 }
 
-// Destination returns destination if it's present in the map. Otherwise
-// nil and false are returned.
-// func (p Pusher) Destination(ctx Context) (d chan Mutations, ok bool) {
-// 	if d, ok = p.destinations[ctx]; !ok {
-// 		d = make(chan Mutations, 1)
-// 	}
-// 	return
-// }
-
 // Put mutations to the pusher. Function will panic if pusher contains
 // unknown context.
 func (p Pusher) Put(mutations ...Mutation) {

--- a/mutable/pusher.go
+++ b/mutable/pusher.go
@@ -26,14 +26,18 @@ func (p Pusher) AddDestination(ctx Context, mc chan Mutations) {
 	p.destinations[ctx] = mc
 }
 
+func NewDestination() Destination {
+	return make(chan Mutations, 1)
+}
+
 // Destination returns destination if it's present in the map. Otherwise
 // nil and false are returned.
-func (p Pusher) Destination(ctx Context) (d chan Mutations, ok bool) {
-	if d, ok = p.destinations[ctx]; !ok {
-		d = make(chan Mutations, 1)
-	}
-	return
-}
+// func (p Pusher) Destination(ctx Context) (d chan Mutations, ok bool) {
+// 	if d, ok = p.destinations[ctx]; !ok {
+// 		d = make(chan Mutations, 1)
+// 	}
+// 	return
+// }
 
 // Put mutations to the pusher. Function will panic if pusher contains
 // unknown context.

--- a/mutable/pusher_test.go
+++ b/mutable/pusher_test.go
@@ -10,7 +10,7 @@ import (
 func TestPusher(t *testing.T) {
 	p := mutable.NewPusher()
 	ctx1 := mutable.Mutable()
-	d, _ := p.Destination(ctx1)
+	d := mutable.NewDestination()
 
 	p.AddDestination(ctx1, d)
 	var v int

--- a/pipe.go
+++ b/pipe.go
@@ -223,7 +223,11 @@ func (p *Pipe) AddLine(l Line) <-chan struct{} {
 			p.pusher.Put(
 				mle.Context.Mutate(
 					func() error {
-						mle.executors = append(mle.executors, r.executor(mle.Destination, routeIdx))
+						le := r.executor(mle.Destination, routeIdx)
+						if err := le.startHook(p.ctx); err != nil {
+							return fmt.Errorf("line failed to start: %w", err)
+						}
+						mle.executors = append(mle.executors, le)
 						cancelFn()
 						return nil
 					},

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -503,12 +503,11 @@ func TestAddLine(t *testing.T) {
 			assertEqual(t, "samples", sink2.Counter.Samples, 862*bufferSize)
 		}
 	}
-	// t.Run("async", addLine(true))
+	t.Run("async", addLine(true))
 	t.Run("sync", addLine(false))
 }
 
 func TestAddLineMultiLine(t *testing.T) {
-
 	sink1 := &mock.Sink{Discard: true}
 	mut := mutable.Mutable()
 	sink2 := &mock.Sink{Discard: true}
@@ -547,15 +546,15 @@ func TestAddLineMultiLine(t *testing.T) {
 		}).Source(),
 		Sink: sink3.Sink(),
 	})
-	// <-p.AddLine(pipe.Line{
-	// 	Context: mut,
-	// 	Source: (&mock.Source{
-	// 		Limit:    862 * bufferSize,
-	// 		Channels: 2,
-	// 		Value:    2,
-	// 	}).Source(),
-	// 	Sink: sink4.Sink(),
-	// })
+	<-p.AddLine(pipe.Line{
+		Context: mut,
+		Source: (&mock.Source{
+			Limit:    862 * bufferSize,
+			Channels: 2,
+			Value:    2,
+		}).Source(),
+		Sink: sink4.Sink(),
+	})
 
 	err = pipe.Wait(errc)
 	assertNil(t, "wait error", err)

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -23,7 +23,7 @@ func TestLineBindingFail(t *testing.T) {
 		errorBinding = errors.New("binding error")
 		bufferSize   = 512
 	)
-	testBinding := func(l pipe.Starter) func(*testing.T) {
+	testBinding := func(l pipe.Line) func(*testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 			_, err := pipe.New(bufferSize, l)
@@ -36,7 +36,7 @@ func TestLineBindingFail(t *testing.T) {
 		}
 	}
 	t.Run("source", testBinding(
-		pipe.AsyncLine{
+		pipe.Line{
 			Source: (&mock.Source{
 				ErrorOnMake: errorBinding,
 			}).Source(),
@@ -47,7 +47,7 @@ func TestLineBindingFail(t *testing.T) {
 		},
 	))
 	t.Run("processor", testBinding(
-		pipe.AsyncLine{
+		pipe.Line{
 			Source: (&mock.Source{}).Source(),
 			Processors: pipe.Processors(
 				(&mock.Processor{
@@ -58,7 +58,7 @@ func TestLineBindingFail(t *testing.T) {
 		},
 	))
 	t.Run("sink", testBinding(
-		pipe.AsyncLine{
+		pipe.Line{
 			Source: (&mock.Source{}).Source(),
 			Processors: pipe.Processors(
 				(&mock.Processor{}).Processor(),
@@ -69,7 +69,7 @@ func TestLineBindingFail(t *testing.T) {
 		},
 	))
 	t.Run("ok", testBinding(
-		pipe.AsyncLine{
+		pipe.Line{
 			Source: (&mock.Source{}).Source(),
 			Processors: pipe.Processors(
 				(&mock.Processor{}).Processor(),
@@ -90,7 +90,7 @@ func TestSimplePipe(t *testing.T) {
 
 	p, err := pipe.New(
 		bufferSize,
-		pipe.AsyncLine{
+		pipe.Line{
 			Source:     source.Source(),
 			Processors: pipe.Processors(proc1.Processor()),
 			Sink:       sink1.Sink(),
@@ -114,7 +114,7 @@ func TestReset(t *testing.T) {
 
 	p, err := pipe.New(
 		bufferSize,
-		pipe.AsyncLine{
+		pipe.Line{
 			Source: source.Source(),
 			Sink:   sink.Sink(),
 		},
@@ -139,11 +139,10 @@ func TestSync(t *testing.T) {
 
 	p, err := pipe.New(
 		bufferSize,
-		pipe.SyncLines{
-			pipe.Line{
-				Source: source.Source(),
-				Sink:   sink.Sink(),
-			},
+		pipe.Line{
+			Context: mutable.Mutable(),
+			Source:  source.Source(),
+			Sink:    sink.Sink(),
 		},
 	)
 	assertNil(t, "error", err)
@@ -169,17 +168,15 @@ func TestMultiple(t *testing.T) {
 	mctx := mutable.Mutable()
 	p, err := pipe.New(
 		bufferSize,
-		pipe.SyncLines{
-			pipe.Line{
-				Context: mctx,
-				Source:  source1.Source(),
-				Sink:    sink1.Sink(),
-			},
-			pipe.Line{
-				Context: mctx,
-				Source:  source2.Source(),
-				Sink:    sink2.Sink(),
-			},
+		pipe.Line{
+			Context: mctx,
+			Source:  source1.Source(),
+			Sink:    sink1.Sink(),
+		},
+		pipe.Line{
+			Context: mctx,
+			Source:  source2.Source(),
+			Sink:    sink2.Sink(),
 		},
 	)
 	assertNil(t, "error", err)

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -211,20 +211,16 @@ func TestLines(t *testing.T) {
 
 	testLines := func(assertFn assertFunc, mocks ...mockLine) func(*testing.T) {
 		return func(t *testing.T) {
-			lines := make([]*pipe.LineRunner, 0, len(mocks))
+			lines := make([]pipe.Line, 0, len(mocks))
 			for i := range mocks {
-				r, err := pipe.Line{
+				l := pipe.Line{
 					Source:     mocks[i].Source.Source(),
 					Processors: pipe.Processors(mocks[i].Processor.Processor()),
 					Sink:       mocks[i].Sink.Sink(),
-				}.Runner(bufferSize, nil)
-				assertNil(t, "runner error", err)
-				lines = append(lines, r)
+				}
+				lines = append(lines, l)
 			}
-			runner := pipe.MultiLineRunner{
-				Lines: lines,
-			}
-			err := runner.Run(context.Background())
+			err := pipe.Run(context.Background(), bufferSize, lines...)
 			assertFn(t, err, mocks...)
 		}
 	}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -572,37 +572,34 @@ func TestAddLineMultiLine(t *testing.T) {
 	assertEqual(t, "samples", sink4.Counter.Samples, 862*bufferSize)
 }
 
-// func TestInsertProcessor(t *testing.T) {
-// 	bufferSize := 2
-// 	testInsert := func(pos int) func(*testing.T) {
-// 		return func(t *testing.T) {
-// 			t.Helper()
-// 			p, err := pipe.New(bufferSize, pipe.Line{
-// 				Source: (&mock.Source{
-// 					Limit:    500,
-// 					Channels: 2,
-// 				}).Source(),
-// 				Processors: pipe.Processors((&mock.Processor{}).Processor()),
-// 				Sink:       (&mock.Sink{Discard: true}).Sink(),
-// 			})
-// 			assertNil(t, "pipe error", err)
+func TestInsertProcessor(t *testing.T) {
+	bufferSize := 2
+	testInsert := func(pos int) func(*testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
+			p, err := pipe.New(bufferSize, pipe.Line{
+				Source: (&mock.Source{
+					Limit:    500,
+					Channels: 2,
+				}).Source(),
+				Processors: pipe.Processors((&mock.Processor{}).Processor()),
+				Sink:       (&mock.Sink{Discard: true}).Sink(),
+			})
+			assertNil(t, "pipe error", err)
+			errc := p.Start(context.Background())
 
-// 			// l := p.Lines[0]
-// 			// a := p.Async(context.Background())
-// 			errc := p.Start(context.Background())
+			proc := &mock.Processor{}
+			<-p.InsertProcessor(0, pos, proc.Processor())
+			assertNil(t, "add error", err)
 
-// 			proc := &mock.Processor{}
-// 			<-p.InsertProcessor(0, pos, proc.Processor())
-// 			assertNil(t, "add error", err)
-
-// 			err = pipe.Wait(errc)
-// 			assertNil(t, "await error", err)
-// 			assertEqual(t, "processed", proc.Counter.Messages > 0, true)
-// 		}
-// 	}
-// 	t.Run("before processor", testInsert(0))
-// 	t.Run("before sink", testInsert(1))
-// }
+			err = pipe.Wait(errc)
+			assertNil(t, "await error", err)
+			assertEqual(t, "processed", proc.Counter.Messages > 0, true)
+		}
+	}
+	t.Run("before processor", testInsert(0))
+	t.Run("before sink", testInsert(1))
+}
 
 // func TestInsertMultiple(t *testing.T) {
 // 	bufferSize := 2

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -458,119 +458,119 @@ func TestLines(t *testing.T) {
 
 }
 
-// func TestAddLine(t *testing.T) {
-// 	addLine := func(async bool) func(*testing.T) {
-// 		return func(t *testing.T) {
-// 			sink1 := &mock.Sink{Discard: true}
-// 			line1 := pipe.Line{
-// 				Source: (&mock.Source{
-// 					Limit:    862 * bufferSize,
-// 					Channels: 2,
-// 				}).Source(),
-// 				Sink: sink1.Sink(),
-// 			}
+func TestAddLine(t *testing.T) {
+	addLine := func(async bool) func(*testing.T) {
+		return func(t *testing.T) {
+			sink1 := &mock.Sink{Discard: true}
+			line1 := pipe.Line{
+				Source: (&mock.Source{
+					Limit:    862 * bufferSize,
+					Channels: 2,
+				}).Source(),
+				Sink: sink1.Sink(),
+			}
 
-// 			var mut mutable.Context
-// 			if !async {
-// 				mut = mutable.Mutable()
-// 			}
-// 			sink2 := &mock.Sink{Discard: true}
-// 			line2 := pipe.Line{
-// 				Context: mut,
-// 				Source: (&mock.Source{
-// 					Limit:    862 * bufferSize,
-// 					Channels: 2,
-// 					Value:    2,
-// 				}).Source(),
-// 				Sink: sink2.Sink(),
-// 			}
+			var mut mutable.Context
+			if !async {
+				mut = mutable.Mutable()
+			}
+			sink2 := &mock.Sink{Discard: true}
+			line2 := pipe.Line{
+				Context: mut,
+				Source: (&mock.Source{
+					Limit:    862 * bufferSize,
+					Channels: 2,
+					Value:    2,
+				}).Source(),
+				Sink: sink2.Sink(),
+			}
 
-// 			p, err := pipe.New(
-// 				bufferSize,
-// 				line1,
-// 			)
-// 			assertNil(t, "error", err)
+			p, err := pipe.New(
+				bufferSize,
+				line1,
+			)
+			assertNil(t, "error", err)
 
-// 			// start
-// 			errc := p.Start(context.Background())
-// 			p.Push(p.AddLine(line2))
-// 			assertNil(t, "error", err)
+			// start
+			errc := p.Start(context.Background())
+			p.Push(p.AddLine(line2))
+			assertNil(t, "error", err)
 
-// 			err = pipe.Wait(errc)
-// 			assertEqual(t, "messages", sink1.Counter.Messages, 862)
-// 			assertEqual(t, "samples", sink1.Counter.Samples, 862*bufferSize)
-// 			assertEqual(t, "messages", sink2.Counter.Messages, 862)
-// 			assertEqual(t, "samples", sink2.Counter.Samples, 862*bufferSize)
-// 		}
-// 	}
-// 	t.Run("async", addLine(true))
-// 	t.Run("sync", addLine(false))
-// }
+			_ = pipe.Wait(errc)
+			assertEqual(t, "messages", sink1.Counter.Messages, 862)
+			assertEqual(t, "samples", sink1.Counter.Samples, 862*bufferSize)
+			assertEqual(t, "messages", sink2.Counter.Messages, 862)
+			assertEqual(t, "samples", sink2.Counter.Samples, 862*bufferSize)
+		}
+	}
+	t.Run("async", addLine(true))
+	t.Run("sync", addLine(false))
+}
 
-// func TestAddLineMultiLine(t *testing.T) {
-// 	sink1 := &mock.Sink{Discard: true}
-// 	line1 := pipe.Line{
-// 		Source: (&mock.Source{
-// 			Limit:    862 * bufferSize,
-// 			Channels: 2,
-// 		}).Source(),
-// 		Sink: sink1.Sink(),
-// 	}
+func TestAddLineMultiLine(t *testing.T) {
+	sink1 := &mock.Sink{Discard: true}
+	line1 := pipe.Line{
+		Source: (&mock.Source{
+			Limit:    862 * bufferSize,
+			Channels: 2,
+		}).Source(),
+		Sink: sink1.Sink(),
+	}
 
-// 	mut := mutable.Mutable()
-// 	sink2 := &mock.Sink{Discard: true}
-// 	line2 := pipe.Line{
-// 		Context: mut,
-// 		Source: (&mock.Source{
-// 			Limit:    862 * bufferSize,
-// 			Channels: 2,
-// 			Value:    2,
-// 		}).Source(),
-// 		Sink: sink2.Sink(),
-// 	}
-// 	sink3 := &mock.Sink{Discard: true}
-// 	line3 := pipe.Line{
-// 		Context: mut,
-// 		Source: (&mock.Source{
-// 			Limit:    862 * bufferSize,
-// 			Channels: 2,
-// 			Value:    2,
-// 		}).Source(),
-// 		Sink: sink3.Sink(),
-// 	}
-// 	sink4 := &mock.Sink{Discard: true}
-// 	line4 := pipe.Line{
-// 		Context: mut,
-// 		Source: (&mock.Source{
-// 			Limit:    862 * bufferSize,
-// 			Channels: 2,
-// 			Value:    2,
-// 		}).Source(),
-// 		Sink: sink4.Sink(),
-// 	}
+	mut := mutable.Mutable()
+	sink2 := &mock.Sink{Discard: true}
+	line2 := pipe.Line{
+		Context: mut,
+		Source: (&mock.Source{
+			Limit:    862 * bufferSize,
+			Channels: 2,
+			Value:    2,
+		}).Source(),
+		Sink: sink2.Sink(),
+	}
+	sink3 := &mock.Sink{Discard: true}
+	line3 := pipe.Line{
+		Context: mut,
+		Source: (&mock.Source{
+			Limit:    862 * bufferSize,
+			Channels: 2,
+			Value:    2,
+		}).Source(),
+		Sink: sink3.Sink(),
+	}
+	sink4 := &mock.Sink{Discard: true}
+	line4 := pipe.Line{
+		Context: mut,
+		Source: (&mock.Source{
+			Limit:    862 * bufferSize,
+			Channels: 2,
+			Value:    2,
+		}).Source(),
+		Sink: sink4.Sink(),
+	}
 
-// 	p, err := pipe.New(
-// 		bufferSize,
-// 		line1,
-// 		line2,
-// 	)
-// 	assertNil(t, "error", err)
+	p, err := pipe.New(
+		bufferSize,
+		line1,
+		line2,
+	)
+	assertNil(t, "error", err)
 
-// 	// start
-// 	errc := p.Start(context.Background())
-// 	p.Push(p.AddLine(line3), p.AddLine(line4))
-// 	assertNil(t, "error", err)
+	// start
+	errc := p.Start(context.Background())
+	p.Push(p.AddLine(line3), p.AddLine(line4))
+	assertNil(t, "error", err)
 
-// 	err = pipe.Wait(errc)
-// 	assertEqual(t, "messages", sink1.Counter.Messages, 862)
-// 	assertEqual(t, "samples", sink1.Counter.Samples, 862*bufferSize)
-// 	assertEqual(t, "messages", sink2.Counter.Messages, 862)
-// 	assertEqual(t, "samples", sink2.Counter.Samples, 862*bufferSize)
-// 	assertEqual(t, "messages", sink3.Counter.Messages, 862)
-// 	assertEqual(t, "samples", sink3.Counter.Samples, 862*bufferSize)
-// 	assertEqual(t, "messages", sink4.Counter.Messages, 862)
-// 	assertEqual(t, "samples", sink4.Counter.Samples, 862*bufferSize)
-// }
+	_ = pipe.Wait(errc)
+	assertEqual(t, "messages", sink1.Counter.Messages, 862)
+	assertEqual(t, "samples", sink1.Counter.Samples, 862*bufferSize)
+	assertEqual(t, "messages", sink2.Counter.Messages, 862)
+	assertEqual(t, "samples", sink2.Counter.Samples, 862*bufferSize)
+	assertEqual(t, "messages", sink3.Counter.Messages, 862)
+	assertEqual(t, "samples", sink3.Counter.Samples, 862*bufferSize)
+	assertEqual(t, "messages", sink4.Counter.Messages, 862)
+	assertEqual(t, "samples", sink4.Counter.Samples, 862*bufferSize)
+}
 
 // func TestInsertProcessor(t *testing.T) {
 // 	bufferSize := 2

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -503,7 +503,7 @@ func TestAddLine(t *testing.T) {
 			assertEqual(t, "samples", sink2.Counter.Samples, 862*bufferSize)
 		}
 	}
-	t.Run("async", addLine(true))
+	// t.Run("async", addLine(true))
 	t.Run("sync", addLine(false))
 }
 
@@ -577,7 +577,7 @@ func TestAddLineMultiLine(t *testing.T) {
 // 	testInsert := func(pos int) func(*testing.T) {
 // 		return func(t *testing.T) {
 // 			t.Helper()
-// 			p, err := pipe.New(bufferSize, pipe.Routing{
+// 			p, err := pipe.New(bufferSize, pipe.Line{
 // 				Source: (&mock.Source{
 // 					Limit:    500,
 // 					Channels: 2,
@@ -587,15 +587,15 @@ func TestAddLineMultiLine(t *testing.T) {
 // 			})
 // 			assertNil(t, "pipe error", err)
 
-// 			l := p.Lines[0]
-// 			a := p.Async(context.Background())
+// 			// l := p.Lines[0]
+// 			// a := p.Async(context.Background())
+// 			errc := p.Start(context.Background())
 
 // 			proc := &mock.Processor{}
-// 			err = l.InsertProcessor(pos, proc.Processor())
+// 			<-p.InsertProcessor(0, pos, proc.Processor())
 // 			assertNil(t, "add error", err)
 
-// 			<-a.StartProcessor(l, pos)
-// 			err = a.Await()
+// 			err = pipe.Wait(errc)
 // 			assertNil(t, "await error", err)
 // 			assertEqual(t, "processed", proc.Counter.Messages > 0, true)
 // 		}

--- a/run.go
+++ b/run.go
@@ -9,7 +9,7 @@ import (
 )
 
 type (
-	// executor executes a single DSP operation.
+	// executor executes a single pipe operation.
 	executor interface {
 		execute(context.Context) error
 		startHook(context.Context) error
@@ -207,7 +207,6 @@ func start(ctx context.Context, e executor) <-chan error {
 		if err != io.EOF {
 			errc <- fmt.Errorf("error running: %w", err)
 		}
-		return
 	}()
 	return errc
 }
@@ -229,7 +228,6 @@ func run(ctx context.Context, e executor) (errExec error) {
 		}
 	}()
 
-	// var err error
 	for errExec == nil {
 		errExec = e.execute(ctx)
 	}

--- a/run.go
+++ b/run.go
@@ -20,6 +20,7 @@ type (
 	// lineExecutor is a sequence of bound and ready-to-run DSP components.
 	// All components are running in a single goroutine.
 	lineExecutor struct {
+		route     int
 		started   int
 		executors []executor
 	}

--- a/run.go
+++ b/run.go
@@ -131,6 +131,18 @@ func (mle *multiLineExecutor) execute(ctx context.Context) error {
 	return nil
 }
 
+func (mle *multiLineExecutor) addRoute(ctx context.Context, r *route, routeIdx int, cancelFn context.CancelFunc) mutable.Mutation {
+	return mle.Context.Mutate(func() error {
+		le := r.executor(mle.Destination, routeIdx)
+		if err := le.startHook(ctx); err != nil {
+			return fmt.Errorf("line failed to start: %w", err)
+		}
+		mle.executors = append(mle.executors, le)
+		cancelFn()
+		return nil
+	})
+}
+
 // start executes dsp component in an async context. For successfully
 // started executor an error is returned immediately after it occured.
 func start(ctx context.Context, e executor) <-chan error {

--- a/run.go
+++ b/run.go
@@ -11,7 +11,7 @@ import (
 type (
 	// executor executes a single pipe operation.
 	executor interface {
-		connectOutputs() // resets output fitting states
+		// connectOutputs() // resets output fitting states
 		execute(context.Context) error
 		startHook(context.Context) error
 		flushHook(context.Context) error
@@ -32,14 +32,6 @@ type (
 		Lines []*lineExecutor
 	}
 )
-
-func (r *multiLineExecutor) connectOutputs() {
-	for i := range r.Lines {
-		for _, e := range r.Lines[i].executors {
-			e.connectOutputs()
-		}
-	}
-}
 
 // Execute all components of the line one-by-one.
 func (r *lineExecutor) execute(ctx context.Context) error {

--- a/run.go
+++ b/run.go
@@ -143,7 +143,7 @@ func (mle *multiLineExecutor) addRoute(ctx context.Context, r *route, routeIdx i
 	})
 }
 
-func (mle *multiLineExecutor) insertProcessor(ctx context.Context, line, pos int, proc Processor, cancelFn context.CancelFunc) mutable.Mutation {
+func (mle *multiLineExecutor) startSyncProcessor(ctx context.Context, line, pos int, proc *Processor, cancelFn context.CancelFunc) mutable.Mutation {
 	return mle.Context.Mutate(func() error {
 		defer cancelFn()
 		for _, e := range mle.executors {
@@ -160,7 +160,7 @@ func (mle *multiLineExecutor) insertProcessor(ctx context.Context, line, pos int
 			}
 			e.executors = append(e.executors, nil)
 			copy(e.executors[pos+1:], e.executors[pos:])
-			e.executors[pos] = &proc
+			e.executors[pos] = proc
 			e.started++
 			break
 		}


### PR DESCRIPTION
* Allow index-based access to Lines;
* Remove MultiLineRunner/LineRunner types - provide pipe.Run function instead;